### PR TITLE
fix: Unused vars causing build error

### DIFF
--- a/webapp/_webapp/src/components/message-entry-container/tools/jsonrpc.tsx
+++ b/webapp/_webapp/src/components/message-entry-container/tools/jsonrpc.tsx
@@ -1,17 +1,13 @@
 import { cn } from "@heroui/react";
-import { JsonRpcResult } from "./utils/common";
-import MarkdownComponent from "../../markdown";
 import { LoadingIndicator } from "../../loading-indicator";
-import { useState } from "react";
 
 type JsonRpcProps = {
   functionName: string;
-  jsonRpcResult: JsonRpcResult;
   preparing: boolean;
   animated: boolean;
 };
 
-export const JsonRpc = ({ functionName, jsonRpcResult, preparing, animated }: JsonRpcProps) => {
+export const JsonRpc = ({ functionName, preparing, animated }: JsonRpcProps) => {
 
   if (preparing) {
     return (

--- a/webapp/_webapp/src/components/message-entry-container/tools/tools.tsx
+++ b/webapp/_webapp/src/components/message-entry-container/tools/tools.tsx
@@ -60,7 +60,6 @@ export default function Tools({ messageId, functionName, message, error, prepari
     return (
       <JsonRpc
         functionName={functionName}
-        jsonRpcResult={jsonRpcResult || UNKNOWN_JSONRPC_RESULT}
         preparing={preparing}
         animated={animated}
       />
@@ -70,7 +69,7 @@ export default function Tools({ messageId, functionName, message, error, prepari
   // fallback to unknown tool card if the json rpc result is not defined
   if (jsonRpcResult) {
     return (
-      <JsonRpc functionName={functionName} jsonRpcResult={jsonRpcResult} preparing={preparing} animated={animated} />
+      <JsonRpc functionName={functionName} preparing={preparing} animated={animated} />
     );
   } else {
     return <UnknownToolCard functionName={functionName} message={message} animated={animated} />;


### PR DESCRIPTION
This PR removes unused vars that is causing the chrome extension build error due to TypeScript's strict compilation rules. 