### PR TITLE
chore: disable xtramcp and prompts

### DIFF
--- a/internal/api/user/list_prompts.go
+++ b/internal/api/user/list_prompts.go
@@ -3,64 +3,53 @@ package user
 import (
 	"context"
 	"sort"
-	"time"
 
 	"paperdebugger/internal/api/mapper"
 	"paperdebugger/internal/libs/contextutil"
 	userv1 "paperdebugger/pkg/gen/api/user/v1"
-
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 var defaultPrompts = []*userv1.Prompt{
 	// {
-	// 	Id:           "1",
+	// 	Id:           "2",
 	// 	CreatedAt:    timestamppb.New(time.Time{}),
 	// 	UpdatedAt:    timestamppb.New(time.Time{}),
-	// 	Title:        "Enhance Academic Writing (Powered by XtraGPT)",
-	// 	Content:      "Suggest context-aware academic paper writing enhancements for the selected text.",
+	// 	Title:        "Search Relevant Papers (Powered by XtraMCP)",
+	// 	Content:      "First, understand my paper and extract the key ideas into an optimized query to find papers that are relevant to my work. Then search for relevant papers to read.\n\nOptional Args:\ntop_k: 10\nStart Date: None (e.g. 2018-12-31)\nEnd Date: None (e.g. 2025-12-31)",
 	// 	IsUserPrompt: false,
 	// },
-	{
-		Id:           "2",
-		CreatedAt:    timestamppb.New(time.Time{}),
-		UpdatedAt:    timestamppb.New(time.Time{}),
-		Title:        "Search Relevant Papers (Powered by XtraMCP)",
-		Content:      "First, understand my paper and extract the key ideas into an optimized query to find papers that are relevant to my work. Then search for relevant papers to read.\n\nOptional Args:\ntop_k: 10\nStart Date: None (e.g. 2018-12-31)\nEnd Date: None (e.g. 2025-12-31)",
-		IsUserPrompt: false,
-	},
-	{
-		Id:           "3",
-		CreatedAt:    timestamppb.New(time.Time{}),
-		UpdatedAt:    timestamppb.New(time.Time{}),
-		Title:        "Paper Review (Powered by XtraMCP)",
-		Content:      "Call review_paper and evaluate my paper.\n\nOptional Args:\nTarget Venue: None (e.g. ICML, NeurIPS, CVPR)\nSeverity Level (blocker | major | minor | nit): Major\nSpecific Sections (default: entire paper): None (e.g. Abstract, Results, <section name in paper>)",
-		IsUserPrompt: false,
-	},
-	{
-		Id:           "4",
-		CreatedAt:    timestamppb.New(time.Time{}),
-		UpdatedAt:    timestamppb.New(time.Time{}),
-		Title:        "Verify Citations (Powered by XtraMCP)",
-		Content:      "Call verify_citations to check the validity of all citations in my paper and identify any potential issues such as incorrect formatting, missing information, or inaccurate references.",
-		IsUserPrompt: false,
-	},
-	{
-		Id:           "5",
-		CreatedAt:    timestamppb.New(time.Time{}),
-		UpdatedAt:    timestamppb.New(time.Time{}),
-		Title:        "Deep Research (Powered by XtraMCP)",
-		Content:      "First, understand my paper and extract the key ideas into an optimized query. Do deep research and compare my paper against others.",
-		IsUserPrompt: false,
-	},
-	{
-		Id:           "6",
-		CreatedAt:    timestamppb.New(time.Time{}),
-		UpdatedAt:    timestamppb.New(time.Time{}),
-		Title:        "Online Research (Powered by XtraMCP)",
-		Content:      "Understand my paper and run online search to find the latest papers related to my work.",
-		IsUserPrompt: false,
-	},
+	// {
+	// 	Id:           "3",
+	// 	CreatedAt:    timestamppb.New(time.Time{}),
+	// 	UpdatedAt:    timestamppb.New(time.Time{}),
+	// 	Title:        "Paper Review (Powered by XtraMCP)",
+	// 	Content:      "Call review_paper and evaluate my paper.\n\nOptional Args:\nTarget Venue: None (e.g. ICML, NeurIPS, CVPR)\nSeverity Level (blocker | major | minor | nit): Major\nSpecific Sections (default: entire paper): None (e.g. Abstract, Results, <section name in paper>)",
+	// 	IsUserPrompt: false,
+	// },
+	// {
+	// 	Id:           "4",
+	// 	CreatedAt:    timestamppb.New(time.Time{}),
+	// 	UpdatedAt:    timestamppb.New(time.Time{}),
+	// 	Title:        "Verify Citations (Powered by XtraMCP)",
+	// 	Content:      "Call verify_citations to check the validity of all citations in my paper and identify any potential issues such as incorrect formatting, missing information, or inaccurate references.",
+	// 	IsUserPrompt: false,
+	// },
+	// {
+	// 	Id:           "5",
+	// 	CreatedAt:    timestamppb.New(time.Time{}),
+	// 	UpdatedAt:    timestamppb.New(time.Time{}),
+	// 	Title:        "Deep Research (Powered by XtraMCP)",
+	// 	Content:      "First, understand my paper and extract the key ideas into an optimized query. Do deep research and compare my paper against others.",
+	// 	IsUserPrompt: false,
+	// },
+	// {
+	// 	Id:           "6",
+	// 	CreatedAt:    timestamppb.New(time.Time{}),
+	// 	UpdatedAt:    timestamppb.New(time.Time{}),
+	// 	Title:        "Online Research (Powered by XtraMCP)",
+	// 	Content:      "Understand my paper and run online search to find the latest papers related to my work.",
+	// 	IsUserPrompt: false,
+	// },
 }
 
 func (s *UserServer) ListPrompts(

--- a/internal/services/toolkit/client/utils_v2.go
+++ b/internal/services/toolkit/client/utils_v2.go
@@ -13,7 +13,6 @@ import (
 	"paperdebugger/internal/libs/logger"
 	"paperdebugger/internal/services"
 	"paperdebugger/internal/services/toolkit/registry"
-	"paperdebugger/internal/services/toolkit/tools/xtramcp"
 	chatv2 "paperdebugger/pkg/gen/api/chat/v2"
 	"strings"
 	"time"
@@ -145,22 +144,22 @@ func initializeToolkitV2(
 
 	logger.Info("[AI Client V2] Registered static LaTeX tools", "count", 0)
 
-	// Load tools dynamically from backend
-	xtraMCPLoader := xtramcp.NewXtraMCPLoaderV2(db, projectService, cfg.XtraMCPURI)
+	// // Load tools dynamically from backend
+	// xtraMCPLoader := xtramcp.NewXtraMCPLoaderV2(db, projectService, cfg.XtraMCPURI)
 
-	// initialize MCP session first and log session ID
-	sessionID, err := xtraMCPLoader.InitializeMCP()
-	if err != nil {
-		logger.Errorf("[XtraMCP Client] Failed to initialize XtraMCP session: %v", err)
-	} else {
-		logger.Info("[XtraMCP Client] XtraMCP session initialized", "sessionID", sessionID)
+	// // initialize MCP session first and log session ID
+	// sessionID, err := xtraMCPLoader.InitializeMCP()
+	// if err != nil {
+	// 	logger.Errorf("[XtraMCP Client] Failed to initialize XtraMCP session: %v", err)
+	// } else {
+	// 	logger.Info("[XtraMCP Client] XtraMCP session initialized", "sessionID", sessionID)
 
-		// dynamically load all tools from XtraMCP backend
-		err = xtraMCPLoader.LoadToolsFromBackend(toolRegistry)
-		if err != nil {
-			logger.Errorf("[XtraMCP Client] Failed to load XtraMCP tools: %v", err)
-		}
-	}
+	// 	// dynamically load all tools from XtraMCP backend
+	// 	err = xtraMCPLoader.LoadToolsFromBackend(toolRegistry)
+	// 	if err != nil {
+	// 		logger.Errorf("[XtraMCP Client] Failed to load XtraMCP tools: %v", err)
+	// 	}
+	// }
 
 	return toolRegistry
 }


### PR DESCRIPTION
To reduce user confusion, xtramcp and its corresponding prompts are temporarily disabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables XtraMCP-related functionality across the app.
> 
> - `internal/api/user/list_prompts.go`: Commented out XtraMCP default prompts; response now returns only user prompts (sorted), plus an empty `defaultPrompts` list
> - `internal/services/toolkit/client/utils_v2.go`: Removed XtraMCP import and commented out initialization/loading of XtraMCP tools from the backend
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b86d0d1c787366eab8a13f7d7c91c52f7817054. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->