### PR TITLE
fix: insertion issue

### DIFF
--- a/webapp/_webapp/src/views/chat/footer/index.tsx
+++ b/webapp/_webapp/src/views/chat/footer/index.tsx
@@ -60,6 +60,8 @@ export function PromptInput() {
 
   const selectedText = useSelectionStore((s) => s.selectedText);
   const clearSelection = useSelectionStore((s) => s.clear);
+  const setSelectedText = useSelectionStore((s) => s.setSelectedText);
+  const setSurroundingText = useSelectionStore((s) => s.setSurroundingText);
 
   const { sendMessageStream } = useSendMessageStream();
   const minimalistMode = useSettingStore((s) => s.minimalistMode);
@@ -75,11 +77,26 @@ export function PromptInput() {
       userId: user?.id,
     });
     setPrompt("");
-    clearSelection();
+    if (selectedText) {
+      setSelectedText(null);
+      setSurroundingText(null);
+    } else {
+      clearSelection();
+    }
     setIsStreaming(true);
     await sendMessageStream(prompt, selectedText ?? "");
     setIsStreaming(false);
-  }, [sendMessageStream, prompt, selectedText, user?.id, setIsStreaming, setPrompt, clearSelection]);
+  }, [
+    sendMessageStream,
+    prompt,
+    selectedText,
+    user?.id,
+    setIsStreaming,
+    setPrompt,
+    clearSelection,
+    setSelectedText,
+    setSurroundingText,
+  ]);
   const handleKeyDown = useCallback(
     async (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       // Check if IME composition is in progress to avoid submitting during Chinese input

--- a/webapp/_webapp/tsconfig.app.json
+++ b/webapp/_webapp/tsconfig.app.json
@@ -16,7 +16,7 @@
     "jsx": "react-jsx",
 
     /* Type resolution */
-    "types": ["bun", "vite/client", "node", "chrome", "react"],
+    "types": ["vite/client", "node", "chrome", "react"],
     "typeRoots": ["./node_modules/@types"],
 
     /* Linting */
@@ -26,5 +26,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
 }


### PR DESCRIPTION
description: 

The "insert" button is always disabled because we cleared the selectedText and selectionRange.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes selection handling in chat input and tightens TS config.
> 
> - In `PromptInput`, `submit()` now conditionally clears selection: if `selectedText` exists, call `setSelectedText(null)` and `setSurroundingText(null)`; otherwise use `clear()`. Added corresponding store getters and updated `useCallback` deps
> - Minor: `tsconfig.app.json` removes `bun` from `types` and excludes `**/*.test.ts(x)` from the app build
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 124531c4e54c4e96cf8370a4c00be162277ad5d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->