### PR TITLE
fix: light and dark mode handling in `Embed Sidebar` mode

### DIFF
--- a/webapp/_webapp/src/index.css
+++ b/webapp/_webapp/src/index.css
@@ -219,12 +219,12 @@ object {
   border: 1px solid;
   background-color: transparent;
   overflow: hidden;
-  @apply overflow-hidden w-full h-full dark:!border-default-200 !border-default-200;
-}
+  @apply overflow-hidden w-full h-full dark:!border-default-200 !border-default-200 text-default-800;
 
-.pd-app-container textarea,
-.pd-app-container input {
-  @apply bg-white dark:bg-default-100 text-default-800;
+  textarea,
+  input {
+    background-color: var(--pd-default-bg);
+  }
 }
 
 .pd-app-control-title-bar {


### PR DESCRIPTION
#114 

Before:
<img height="600" alt="image" src="https://github.com/user-attachments/assets/32803034-163d-42b3-b6df-de76ad257cf8" />

After:
<img height="600" alt="image" src="https://github.com/user-attachments/assets/cca25c62-db54-4b3a-ab63-43d3f9dfca71" />

