### PR TITLE
fix: "\%" early stop

### DIFF
--- a/internal/libs/tex/latexpand.go
+++ b/internal/libs/tex/latexpand.go
@@ -10,9 +10,12 @@ import (
 
 // commentRegex matches a LaTeX comment: an unescaped % and everything after it
 // until end of line. The leading group captures either start-of-line or a
-// non-backslash character so that \% (an escaped percent) is preserved. Pairs
-// of backslashes (\\) before % are treated as a line-break followed by a real
-// comment, matching LaTeX semantics.
+// non-backslash character, then consumes pairs of backslashes (\\) before %.
+// This generalizes to any run of N backslashes preceding %: if N is even
+// (including 0), every backslash pairs up as a literal-backslash escape and
+// the % is unescaped, so the comment is stripped; if N is odd, the final
+// backslash escapes the % itself, so the % (and the surrounding text) is
+// preserved.
 var commentRegex = regexp.MustCompile(`(^|[^\\])((?:\\\\)*)%.*$`)
 
 func removeComments(text string) string {

--- a/internal/libs/tex/latexpand.go
+++ b/internal/libs/tex/latexpand.go
@@ -8,14 +8,20 @@ import (
 	"paperdebugger/internal/libs/shared"
 )
 
+// commentRegex matches a LaTeX comment: an unescaped % and everything after it
+// until end of line. The leading group captures either start-of-line or a
+// non-backslash character so that \% (an escaped percent) is preserved. Pairs
+// of backslashes (\\) before % are treated as a line-break followed by a real
+// comment, matching LaTeX semantics.
+var commentRegex = regexp.MustCompile(`(^|[^\\])((?:\\\\)*)%.*$`)
+
 func removeComments(text string) string {
 	// Split into lines, trim each line and filter empty ones
 	lines := strings.Split(text, "\n")
 	var result []string
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
-		commentRegex := regexp.MustCompile(`%.*$`)
-		cleaned := commentRegex.ReplaceAllString(trimmed, "")
+		cleaned := commentRegex.ReplaceAllString(trimmed, "$1$2")
 		cleaned = strings.TrimSpace(cleaned)
 		if len(cleaned) == 0 {
 			continue

--- a/internal/libs/tex/latexpand_test.go
+++ b/internal/libs/tex/latexpand_test.go
@@ -20,16 +20,25 @@ Hello, world!
 \end{document}`, removeComments(input))
 }
 
-func TestRemoveCommentsPreservesEscapedPercent(t *testing.T) {
-	const input = `accuracy improved by 12\% over baseline % TODO: recheck`
-	assert.Equal(t, `accuracy improved by 12\% over baseline`, removeComments(input))
-}
-
-func TestRemoveCommentsDoubleBackslashBeforePercent(t *testing.T) {
-	const input = `line one \\% this is a real comment after a line break
-next line`
-	assert.Equal(t, `line one \\
-next line`, removeComments(input))
+func TestRemoveCommentsBackslashRunsBeforePercent(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"1 backslash (odd) preserves %", `a\% keep`, `a\% keep`},
+		{"2 backslashes (even) strips comment", `a\\% drop`, `a\\`},
+		{"3 backslashes (odd) preserves %", `a\\\% keep`, `a\\\% keep`},
+		{"4 backslashes (even) strips comment", `a\\\\% drop`, `a\\\\`},
+		{"5 backslashes (odd) preserves %", `a\\\\\% keep`, `a\\\\\% keep`},
+		{"3 backslashes at line start preserves %", `\\\% keep`, `\\\% keep`},
+		{"4 backslashes at line start strips comment", `\\\\% drop`, `\\\\`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, removeComments(tc.input))
+		})
+	}
 }
 
 func TestLatexpand(t *testing.T) {

--- a/internal/libs/tex/latexpand_test.go
+++ b/internal/libs/tex/latexpand_test.go
@@ -20,6 +20,18 @@ Hello, world!
 \end{document}`, removeComments(input))
 }
 
+func TestRemoveCommentsPreservesEscapedPercent(t *testing.T) {
+	const input = `accuracy improved by 12\% over baseline % TODO: recheck`
+	assert.Equal(t, `accuracy improved by 12\% over baseline`, removeComments(input))
+}
+
+func TestRemoveCommentsDoubleBackslashBeforePercent(t *testing.T) {
+	const input = `line one \\% this is a real comment after a line break
+next line`
+	assert.Equal(t, `line one \\
+next line`, removeComments(input))
+}
+
 func TestLatexpand(t *testing.T) {
 	input := map[string]string{
 		"main.tex": `


### PR DESCRIPTION
Previously:
- `%` is used to remove comments, which interfered with literal `\%` in LaTeX documents.

Now:
- Handle `%` properly. Tested for `%`, `\%` and `\\%`.