### PR TITLE
fix: cloudflared probe loop causing constant restarts

### DIFF
--- a/helm-chart/templates/cloudflare.yaml
+++ b/helm-chart/templates/cloudflare.yaml
@@ -33,7 +33,7 @@ spec:
           - name: net.ipv4.ping_group_range
             value: "65532 65532"
       containers:
-        - image: cloudflare/cloudflared:2026.5.0
+        - image: {{ .Values.cloudflared.image }}
           name: cloudflared
           env:
             # Defines an environment variable for the tunnel token.
@@ -55,12 +55,7 @@ spec:
             - 0.0.0.0:2000
             - run
           resources:
-            requests:
-              cpu: 50m
-              memory: 64Mi
-            limits:
-              cpu: 500m
-              memory: 256Mi
+            {{- toYaml .Values.cloudflared.resources | nindent 12 }}
           # cloudflared's /ready returns 200 only when at least one tunnel
           # connection is active. Cloudflare rotates edge connections
           # periodically, so transient /ready failures are expected and

--- a/helm-chart/templates/cloudflare.yaml
+++ b/helm-chart/templates/cloudflare.yaml
@@ -33,7 +33,7 @@ spec:
           - name: net.ipv4.ping_group_range
             value: "65532 65532"
       containers:
-        - image: cloudflare/cloudflared:latest
+        - image: cloudflare/cloudflared:2026.5.0
           name: cloudflared
           env:
             # Defines an environment variable for the tunnel token.
@@ -50,16 +50,33 @@ spec:
             - --protocol
             - http2
             - --loglevel
-            - debug
+            - info
             - --metrics
             - 0.0.0.0:2000
             - run
-          livenessProbe:
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          # cloudflared's /ready returns 200 only when at least one tunnel
+          # connection is active. Cloudflare rotates edge connections
+          # periodically, so transient /ready failures are expected and
+          # cloudflared reconnects on its own. We therefore drop livenessProbe
+          # (which was killing healthy pods on every reconnect) and rely on
+          # startupProbe for first-connect tolerance plus readinessProbe for
+          # rolling-deploy gating.
+          startupProbe:
             httpGet:
-              # Cloudflared has a /ready endpoint which returns 200 if and only if
-              # it has an active connection to Cloudflare's network.
               path: /ready
               port: 2000
-            failureThreshold: 1
-            initialDelaySeconds: 10
             periodSeconds: 10
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 2000
+            periodSeconds: 10
+            failureThreshold: 3

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -19,6 +19,16 @@ paperdebuggerXtraMcpServer:
 nodeSelector: {}
 cloudflareNodeSelector: {}
 
+cloudflared:
+  image: cloudflare/cloudflared:2026.5.0
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+
 mongo:
   in_cluster: true
   uri: "" # if in_cluster is false, use the external mongo instead


### PR DESCRIPTION
## Summary

The cloudflared deployment was hitting ~21 restarts/hour (20,640 restarts over 41 days). Root cause is in the `livenessProbe`:

```yaml
livenessProbe:
  httpGet: { path: /ready, port: 2000 }
  failureThreshold: 1   # ← one failure kills the pod
  periodSeconds: 10
```

`/ready` only returns 200 when at least one tunnel connection is active. Cloudflare rotates edge connections periodically (and packet loss / DNS jitter can briefly drop them too), so a transient non-200 is **expected behavior, not a fault**. With `failureThreshold: 1`, kubelet kills the pod on the first miss → cloudflared graceful-shutdowns (exit 0) → pod restarts → reconnects → next rotation kills it again. Death loop.

## Changes

- **Drop `livenessProbe`.** cloudflared handles reconnection internally; k8s doesn't need to force-kill it.
- **Add `startupProbe`** (`failureThreshold: 30`, `periodSeconds: 10`) — 5-min budget for the initial tunnel connection.
- **Add `readinessProbe`** (`failureThreshold: 3`) — gates rolling deploys so we don't terminate the old pod until the new one is actually connected.
- **Pin image** `cloudflare/cloudflared:latest` → `2026.5.0`. `:latest` blocks rollback and lets a bad upstream push break us silently.
- **`--loglevel debug` → `info`** — debug isn't appropriate for prod and is noisy in logs.
- **Add `resources` requests/limits** — `50m/64Mi` request, `500m/256Mi` limit. cloudflared is lightweight; these leave headroom for spikes.

Kept `replicas: 2` for HA during rolling updates and connection rotation.

## Test plan

- [ ] `helm template helm-chart` renders without error
- [ ] Deploy to staging, confirm both pods reach Ready
- [ ] Watch `kubectl get pod -l pod=cloudflared -w` for 24h, expect 0 restarts
- [ ] Trigger a rolling update, confirm new pod becomes Ready before old terminates
- [ ] Verify tunnel still serves traffic end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)